### PR TITLE
Update Microsoft.PowerShell_profile.ps1

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -1,7 +1,7 @@
 Import-Module -Name Terminal-Icons
 #Set-PoshPrompt -Theme free-ukraine
 # Adjust path to profile according to your theme file location
-oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH/sitecore.omp.json" | Invoke-Expression
+oh-my-posh init pwsh --config "~/AppData/Local/Programs/oh-my-posh/themes/sitecore.omp.json" | Invoke-Expression
 
 # Add PSReadLine
 # https://github.com/PowerShell/PSReadLine


### PR DESCRIPTION
Changed path to generic one - this will also work without a defined environment variable. The creation of this variable seems not to be a part of the installation process anymore.

When the change is accepted - the troubleshooting section also should be updated as POSH_THEMES_PATH variable will no be longer in use. 